### PR TITLE
"time" field renamed to unique "timeFormSave" name to eliminate names conflict...

### DIFF
--- a/assets/components/formsave/mgr/templates/print/fs.rowdata.tpl
+++ b/assets/components/formsave/mgr/templates/print/fs.rowdata.tpl
@@ -1,4 +1,4 @@
 			<tr>
 					<td class="label">[[+key]]</td>
-					<td class="value">[[+key:eq=`time`:then=`[[+value:date=`%Y-%m-%d %H:%M`]]`:else=`[[+value:nl2br]]`]]</td>
+					<td class="value">[[+key:eq=`timeFormSave`:then=`[[+value:date=`%Y-%m-%d %H:%M`]]`:else=`[[+value:nl2br]]`]]</td>
 			</tr>

--- a/assets/components/formsave/mgr/templates/print/fs.rowwrapper.tpl
+++ b/assets/components/formsave/mgr/templates/print/fs.rowwrapper.tpl
@@ -1,5 +1,5 @@
 <tr>
-	<td colspan="2"><h2>[[+formData.time:date=`%Y/%m/%d %H:%M`]]</h2></td>
+	<td colspan="2"><h2>[[+formData.timeFormSave:date=`%Y/%m/%d %H:%M`]]</h2></td>
 </tr>
 [[+content]]
 <tr>

--- a/core/components/formsave/processors/mgr/form/export.php
+++ b/core/components/formsave/processors/mgr/form/export.php
@@ -73,7 +73,13 @@ $forms = $modx->getCollection('fsForm', $query);
 $output = '';
 
 foreach ($forms as $form) {
-	$formData = array_merge($form->toArray(), $form->get('data'));
+	
+	$formData = $form->toArray();
+	// "time" field renamed to unique "timeFormSave" name to eliminate conflict beetween previous "time" name and "time" field inj saved forms
+	$formData['timeFormSave'] = $formData['time'];
+  	unset($formData['time']);
+  	$formData = array_merge($formData, $form->get('data'));
+
 	$rowOutput = '';
 	$count = 0;
 	foreach($formData as $key => $value) {


### PR DESCRIPTION
"time" field renamed to unique "timeFormSave" name to eliminate names conflict beetween previous "time" name and "time" field in saved forms (caused problems in export engine)
