### PR TITLE
Handle case where path to config.core.php includes symlinks.

### DIFF
--- a/assets/components/formsave/connector.php
+++ b/assets/components/formsave/connector.php
@@ -26,10 +26,10 @@
  *
  * @package FormSave
  */
-if (is_file(dirname(dirname(dirname(dirname(__FILE__)))).'/config.core.php')) {
-	require_once dirname(dirname(dirname(dirname(__FILE__)))).'/config.core.php';
+if (is_file(dirname(dirname(dirname(dirname($_SERVER["SCRIPT_FILENAME"])))).'/config.core.php')) {
+	require_once dirname(dirname(dirname(dirname($_SERVER["SCRIPT_FILENAME"])))).'/config.core.php';
 } else {
-	require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.core.php';
+	require_once dirname(dirname(dirname(dirname(dirname($_SERVER["SCRIPT_FILENAME"]))))).'/config.core.php';
 } 
 require_once MODX_CORE_PATH.'config/'.MODX_CONFIG_KEY.'.inc.php';
 require_once MODX_CONNECTORS_PATH.'index.php';


### PR DESCRIPTION
`connector.php` currently uses the PHP magic constant `__FILE__` to specify the current directory and then traverses up using the `dirname()` function to locate `config.core.php`.

Our installation of MODX revolution has its resources directory outside the core directory, and includes it via a symlink instead, with the installation directory being `/srv/modx/revolution/`

`$ ls -l /srv/modx/revolution/` includes the following lines:

`
...
lrwxrwxrwx  1 apache apache    9 Feb 16 17:00 assets -> ../assets
...
-rw-r--r--  1 apache apache  101 Mar 19 15:15 config.core.php
...
`

Since PHP 4.0.2, [`__FILE__` always contains an absolute path with symlinks resolved.](http://php.net/manual/en/language.constants.predefined.php)

In our particular case `__FILE__` resolves to `/srv/modx/assets/components/formsave`. `config.core.php` is found nowhere on that path (it's in `/srv/modx/revolution/`) so `connector.php` fails when trying to open the "view stored forms" component in MODX manager. The following message appears in the apache error log:

`[Sat Apr 12 18:48:58 2014] [error] [client <IP address removed>] PHP Fatal error:  require_once(): Failed opening required '/srv/config.core.php' (include_path='.:/usr/share/pear:/usr/share/php') in /srv/modx/assets/components/formsave/connector.php.new on line 32, referer: <removed>`

A possible work-around is to copy `/srv/modx/revolution/config.core.php` to `/srv/config.core.php`.

This patch replaces the use of `__FILE__` with `$_SERVER["SCRIPT_FILENAME"]` as suggested in [this StackOverflow question](https://stackoverflow.com/questions/3221771/how-do-you-get-php-symlinks-and-file-to-work-together-nicely). I've tested this on MODX Revolution 2.2.13-pl (git) and it works without having to resort to copying config.core.php.

Fixes b03tz/FormSave#19
